### PR TITLE
build: use https over git for submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "prost-build/third-party/protobuf"]
 	path = prost-build/third-party/protobuf
-	url = git@github.com:protocolbuffers/protobuf
+	url = https://github.com/protocolbuffers/protobuf


### PR DESCRIPTION
The git protocol is harder to work behind a proxy.

If I understand it correctly, with https://github.com/tokio-rs/prost/commit/37c4241ae61369c0273814d43cc5da72954e7204 we don't even need this submodule.

cc @aljoscha