### PR TITLE
Fix build with nightly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "prost-build/third-party/protobuf"]
 	path = prost-build/third-party/protobuf
-	url = git@github.com:protocolbuffers/protobuf
+	url = https://github.com/protocolbuffers/protobuf.git


### PR DESCRIPTION
error: failed to load source for dependency `prost`

Caused by:
  Unable to update https://github.com/def-/prost#1dfee4ba

Caused by:
  failed to update submodule `prost-build/third-party/protobuf`

Caused by:
  failed to parse url for submodule `prost-build/third-party/protobuf`: `git@github.com:protocolbuffers/protobuf`