### PR TITLE
decoding: Make allocations fallible

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 
 use core::fmt;
@@ -66,6 +67,12 @@ impl fmt::Display for DecodeError {
             write!(f, "{}.{}: ", message, field)?;
         }
         f.write_str(&self.inner.description)
+    }
+}
+
+impl From<TryReserveError> for DecodeError {
+    fn from(error: TryReserveError) -> Self {
+        DecodeError::new(error.to_string())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -343,7 +343,7 @@ impl Message for Vec<u8> {
         B: Buf,
     {
         if tag == 1 {
-            bytes::merge(wire_type, self, buf, ctx)
+            bytes::merge_one_copy(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf, ctx)
         }


### PR DESCRIPTION
This PR makes allocations in the decoding path of a `Message` fallible. See https://github.com/tokio-rs/prost/pull/974 with more details for what exactly changed.